### PR TITLE
[it]: Fixed the password translation for Italian language

### DIFF
--- a/locales/it/php.json
+++ b/locales/it/php.json
@@ -44,7 +44,7 @@
     "attributes.name": "nome",
     "attributes.national_code": "codice nazionale",
     "attributes.number": "numero",
-    "attributes.password": "parola d'ordine",
+    "attributes.password": "password",
     "attributes.password_confirmation": "conferma password",
     "attributes.phone": "telefono",
     "attributes.photo": "foto",


### PR DESCRIPTION
Fixed the italian string for "password" (was "parola d'ordine")